### PR TITLE
fix z.shape typo in reading geotiff

### DIFF
--- a/src/python/geoclaw/topotools.py
+++ b/src/python/geoclaw/topotools.py
@@ -780,7 +780,7 @@ class Topography(object):
                 self._Z = numpy.flipud(z)
                 self._x = numpy.linspace(x_origin, 
                                    x_origin + (z.shape[0] - 1) * dx, z.shape[0])
-                self._y = numpy.linspace(y_origin - (z.shape[0] - 1) * dy, 
+                self._y = numpy.linspace(y_origin - (z.shape[1] - 1) * dy, 
                                    y_origin, z.shape[1])
 
 


### PR DESCRIPTION
@mandli: I think this works ok for reading tif files we use from NCEI, although I'm still sorting out what other formats are in use.  Probably fine to add this for now.

But first, I think there's a typo that's fixed in this PR.