### PR TITLE
suggested way to specify test data in setrun_test.py

### DIFF
--- a/examples/tsunami/bowl-slosh/setrun_test.py
+++ b/examples/tsunami/bowl-slosh/setrun_test.py
@@ -1,0 +1,417 @@
+"""
+Module to set up run time parameters for Clawpack.
+
+The values set in the function setrun are then written out to data files
+that will be read in by the Fortran code.
+
+"""
+
+import os
+import numpy as np
+import clawpack.geoclaw.fgmax_tools as fgmax_tools
+
+
+
+#------------------------------
+def setrun(claw_pkg='geoclaw'):
+#------------------------------
+
+    """
+    Define the parameters used for running Clawpack.
+
+    INPUT:
+        claw_pkg expected to be "geoclaw" for this setrun.
+
+    OUTPUT:
+        rundata - object of class ClawRunData
+
+    """
+
+    from clawpack.clawutil import data
+
+    assert claw_pkg.lower() == 'geoclaw',  "Expected claw_pkg = 'geoclaw'"
+
+    num_dim = 2
+    rundata = data.ClawRunData(claw_pkg, num_dim)
+
+    #------------------------------------------------------------------
+    # GeoClaw specific parameters:
+    #------------------------------------------------------------------
+    rundata = setgeo(rundata)
+
+    #------------------------------------------------------------------
+    # Standard Clawpack parameters to be written to claw.data:
+    #   (or to amr2ez.data for AMR)
+    #------------------------------------------------------------------
+    clawdata = rundata.clawdata  # initialized when rundata instantiated
+
+
+    # Set single grid parameters first.
+    # See below for AMR parameters.
+
+
+    # ---------------
+    # Spatial domain:
+    # ---------------
+
+    # Number of space dimensions:
+    clawdata.num_dim = num_dim
+
+    # Lower and upper edge of computational domain:
+    clawdata.lower[0] = -2.0
+    clawdata.upper[0] = 2.0
+
+    clawdata.lower[1] = -2.0
+    clawdata.upper[1] = 2.0
+
+
+
+    # Number of grid cells: Coarsest grid
+    clawdata.num_cells[0] = 41
+    clawdata.num_cells[1] = 41
+
+
+    # ---------------
+    # Size of system:
+    # ---------------
+
+    # Number of equations in the system:
+    clawdata.num_eqn = 3
+
+    # Number of auxiliary variables in the aux array (initialized in setaux)
+    clawdata.num_aux = 1
+
+    # Index of aux array corresponding to capacity function, if there is one:
+    clawdata.capa_index = 0
+
+
+
+    # -------------
+    # Initial time:
+    # -------------
+
+    clawdata.t0 = 0.0
+
+
+    # Restart from checkpoint file of a previous run?
+    # If restarting, t0 above should be from original run, and the
+    # restart_file 'fort.chkNNNNN' specified below should be in
+    # the OUTDIR indicated in Makefile.
+
+    clawdata.restart = False               # True to restart from prior results
+    clawdata.restart_file = 'fort.chk00006'  # File to use for restart data
+
+    # -------------
+    # Output times:
+    #--------------
+
+    # Specify at what times the results should be written to fort.q files.
+    # Note that the time integration stops after the final output time.
+    # The solution at initial time t0 is always written in addition.
+
+    clawdata.output_style = 1
+
+    if clawdata.output_style == 1:
+        # Output nout frames at equally spaced times up to tfinal:
+        clawdata.num_output_times = 1
+        clawdata.tfinal = 0.5
+        clawdata.output_t0 = True  # output at initial (or restart) time?
+
+    elif clawdata.output_style == 2:
+        # Specify a list of output times.
+        clawdata.output_times = [0.5, 1.0]
+
+    elif clawdata.output_style == 3:
+        # Output every iout timesteps with a total of ntot time steps:
+        clawdata.output_step_interval = 1
+        clawdata.total_steps = 1
+        clawdata.output_t0 = True
+
+
+    clawdata.output_format = 'ascii'      # 'ascii' or 'binary'
+
+    clawdata.output_q_components = 'all'   # could be list such as [True,True]
+    clawdata.output_aux_components = 'none'  # could be list
+    clawdata.output_aux_onlyonce = True    # output aux arrays only at t0
+
+
+
+    # ---------------------------------------------------
+    # Verbosity of messages to screen during integration:
+    # ---------------------------------------------------
+
+    # The current t, dt, and cfl will be printed every time step
+    # at AMR levels <= verbosity.  Set verbosity = 0 for no printing.
+    #   (E.g. verbosity == 2 means print only on levels 1 and 2.)
+    clawdata.verbosity = 3
+
+
+
+    # --------------
+    # Time stepping:
+    # --------------
+
+    # if dt_variable==1: variable time steps used based on cfl_desired,
+    # if dt_variable==0: fixed time steps dt = dt_initial will always be used.
+    clawdata.dt_variable = True
+
+    # Initial time step for variable dt.
+    # If dt_variable==0 then dt=dt_initial for all steps:
+    clawdata.dt_initial = 0.0001
+
+    # Max time step to be allowed if variable dt used:
+    clawdata.dt_max = 1e+99
+
+    # Desired Courant number if variable dt used, and max to allow without
+    # retaking step with a smaller dt:
+    clawdata.cfl_desired = 0.75
+    clawdata.cfl_max = 1.0
+
+    # Maximum number of time steps to allow between output times:
+    clawdata.steps_max = 5000
+
+
+
+
+    # ------------------
+    # Method to be used:
+    # ------------------
+
+    # Order of accuracy:  1 => Godunov,  2 => Lax-Wendroff plus limiters
+    clawdata.order = 2
+
+    # Use dimensional splitting? (not yet available for AMR)
+    clawdata.dimensional_split = 'unsplit'
+
+    # For unsplit method, transverse_waves can be
+    #  0 or 'none'      ==> donor cell (only normal solver used)
+    #  1 or 'increment' ==> corner transport of waves
+    #  2 or 'all'       ==> corner transport of 2nd order corrections too
+    clawdata.transverse_waves = 2
+
+    # Number of waves in the Riemann solution:
+    clawdata.num_waves = 3
+
+    # List of limiters to use for each wave family:
+    # Required:  len(limiter) == num_waves
+    # Some options:
+    #   0 or 'none'     ==> no limiter (Lax-Wendroff)
+    #   1 or 'minmod'   ==> minmod
+    #   2 or 'superbee' ==> superbee
+    #   3 or 'mc'       ==> MC limiter
+    #   4 or 'vanleer'  ==> van Leer
+    clawdata.limiter = ['mc', 'mc', 'mc']
+
+    clawdata.use_fwaves = True    # True ==> use f-wave version of algorithms
+
+    # Source terms splitting:
+    #   src_split == 0 or 'none'    ==> no source term (src routine never called)
+    #   src_split == 1 or 'godunov' ==> Godunov (1st order) splitting used,
+    #   src_split == 2 or 'strang'  ==> Strang (2nd order) splitting used,  not recommended.
+    clawdata.source_split = 'godunov'
+
+
+    # --------------------
+    # Boundary conditions:
+    # --------------------
+
+    # Number of ghost cells (usually 2)
+    clawdata.num_ghost = 2
+
+    # Choice of BCs at xlower and xupper:
+    #   0 => user specified (must modify bcN.f to use this option)
+    #   1 => extrapolation (non-reflecting outflow)
+    #   2 => periodic (must specify this at both boundaries)
+    #   3 => solid wall for systems where q(2) is normal velocity
+
+    clawdata.bc_lower[0] = 'extrap'
+    clawdata.bc_upper[0] = 'extrap'
+
+    clawdata.bc_lower[1] = 'extrap'
+    clawdata.bc_upper[1] = 'extrap'
+
+    # Specify when checkpoint files should be created that can be
+    # used to restart a computation.
+
+    clawdata.checkpt_style = 0
+
+    if clawdata.checkpt_style == 0:
+        # Do not checkpoint at all
+        pass
+
+    elif np.abs(clawdata.checkpt_style) == 1:
+        # Checkpoint only at tfinal.
+        pass
+
+    elif np.abs(clawdata.checkpt_style) == 2:
+        # Specify a list of checkpoint times.
+        clawdata.checkpt_times = [0.1,0.15]
+
+    elif np.abs(clawdata.checkpt_style) == 3:
+        # Checkpoint every checkpt_interval timesteps (on Level 1)
+        # and at the final time.
+        clawdata.checkpt_interval = 5
+
+
+    # ---------------
+    # AMR parameters:
+    # ---------------
+    amrdata = rundata.amrdata
+
+    # max number of refinement levels:
+    amrdata.amr_levels_max = 2
+
+    # List of refinement ratios at each level (length at least mxnest-1)
+    amrdata.refinement_ratios_x = [4,4]
+    amrdata.refinement_ratios_y = [4,4]
+    amrdata.refinement_ratios_t = [2,6]
+
+
+    # Specify type of each aux variable in amrdata.auxtype.
+    # This must be a list of length maux, each element of which is one of:
+    #   'center',  'capacity', 'xleft', or 'yleft'  (see documentation).
+
+    amrdata.aux_type = ['center']
+
+
+    # Flag using refinement routine flag2refine rather than richardson error
+    amrdata.flag_richardson = False    # use Richardson?
+    amrdata.flag2refine = True
+
+    # steps to take on each level L between regriddings of level L+1:
+    amrdata.regrid_interval = 3
+
+    # width of buffer zone around flagged points:
+    # (typically the same as regrid_interval so waves don't escape):
+    amrdata.regrid_buffer_width  = 2
+
+    # clustering alg. cutoff for (# flagged pts) / (total # of cells refined)
+    # (closer to 1.0 => more small grids may be needed to cover flagged cells)
+    amrdata.clustering_cutoff = 0.700000
+
+    # print info about each regridding up to this level:
+    amrdata.verbosity_regrid = 0
+
+
+    #  ----- For developers -----
+    # Toggle debugging print statements:
+    amrdata.dprint = False      # print domain flags
+    amrdata.eprint = False      # print err est flags
+    amrdata.edebug = False      # even more err est flags
+    amrdata.gprint = False      # grid bisection/clustering
+    amrdata.nprint = False      # proper nesting output
+    amrdata.pprint = False      # proj. of tagged points
+    amrdata.rprint = False      # print regridding summary
+    amrdata.sprint = False      # space/memory output
+    amrdata.tprint = False      # time step reporting each level
+    amrdata.uprint = False      # update/upbnd reporting
+
+    # More AMR parameters can be set -- see the defaults in pyclaw/data.py
+
+    # == setregions.data values ==
+    regions = rundata.regiondata.regions
+    # to specify regions of refinement append lines of the form
+    #  [minlevel,maxlevel,t1,t2,x1,x2,y1,y2]
+
+    # == setgauges.data values ==
+    # for gauges append lines of the form  [gaugeno, x, y, t1, t2]
+    # rundata.gaugedata.gauges.append([])
+    rundata.gaugedata.gauges.append([1, 0.5, 0.5, 0, 1e10])
+
+    # == fgmax.data values ==
+    rundata.fgmax_data.num_fgmax_val = 2
+    fgmax_grids = rundata.fgmax_data.fgmax_grids  # empty list to start
+    # Now append to this list objects of class fgmax_tools.FGmaxGrid
+    # specifying any fgmax grids.
+
+    fg = fgmax_tools.FGmaxGrid()
+    fg.point_style = 2       # will specify a 2d grid of points
+    fg.x1 = -2.
+    fg.x2 = 2.
+    fg.y1 = -2.
+    fg.y2 = 2.
+    fg.dx = 0.1
+    fg.tstart_max = 0.        # when to start monitoring max values
+    fg.tend_max = 1.e10       # when to stop monitoring max values
+    fg.dt_check = 0.1         # target time (sec) increment between updating
+                           # max values
+    fg.min_level_check = 2    # which levels to monitor max on
+    fg.arrival_tol = 1.e-2    # tolerance for flagging arrival
+
+    fgmax_grids.append(fg)  # written to fgmax_grids.data
+
+
+    return rundata
+    # end of function setrun
+    # ----------------------
+
+
+#-------------------
+def setgeo(rundata):
+#-------------------
+    """
+    Set GeoClaw specific runtime parameters.
+    For documentation see ....
+    """
+
+    try:
+        geo_data = rundata.geo_data
+    except:
+        print("*** Error, this rundata has no geo_data attribute")
+        raise AttributeError("Missing geo_data attribute")
+
+
+    # == Physics ==
+    geo_data.gravity = 9.81
+    geo_data.coordinate_system = 1
+    geo_data.earth_radius = 6367.5e3
+
+    # == Forcing Options
+    geo_data.coriolis_forcing = False
+
+    # == Algorithm and Initial Conditions ==
+    geo_data.sea_level = -10.0
+    geo_data.dry_tolerance = 1.e-3
+    geo_data.friction_forcing = False
+    geo_data.manning_coefficient = 0.0
+    geo_data.friction_depth = 1.e6
+
+    # Refinement data
+    refinement_data = rundata.refinement_data
+    refinement_data.wave_tolerance = 1.e-2
+    refinement_data.variable_dt_refinement_ratios = True
+
+    # == settopo.data values ==
+    topo_data = rundata.topo_data
+    # for topography, append lines of the form
+    #    [topotype, fname]
+    topo_data.topofiles.append([2, 'bowl.topotype2'])
+
+    # == setdtopo.data values ==
+    dtopo_data = rundata.dtopo_data
+    # for moving topography, append lines of the form :   (<= 1 allowed for now!)
+    #   [topotype, fname]
+
+    # == setqinit.data values ==
+    rundata.qinit_data.qinit_type = 0
+    rundata.qinit_data.qinitfiles = []
+    # for qinit perturbations, append lines of the form: (<= 1 allowed for now!)
+    #   [fname]
+
+    # == fgout grids ==
+    # new style as of v5.9.0 (old rundata.fixed_grid_data is deprecated)
+    # set rundata.fgout_data.fgout_grids to be a
+    # list of objects of class clawpack.geoclaw.fgout_tools.FGoutGrid:
+    #rundata.fgout_data.fgout_grids = []
+
+    return rundata
+    # end of function setgeo
+    # ----------------------
+
+
+
+if __name__ == '__main__':
+    # Set up run-time parameters and write all data files.
+    import sys
+    rundata = setrun(*sys.argv[1:])
+    rundata.write()

--- a/examples/tsunami/bowl-slosh/test_bowl_slosh.py
+++ b/examples/tsunami/bowl-slosh/test_bowl_slosh.py
@@ -7,14 +7,14 @@ To create new regression data use
 """
 
 from pathlib import Path
-import sys
+import sys, os, shutil
 import unittest
 
 import numpy
 
 import clawpack.geoclaw.test as test
-import clawpack.geoclaw.topotools as topotools
-import clawpack.geoclaw.fgmax_tools as fgmax_tools
+
+example_dir = os.getcwd() # where to find setrun_test.py
 
 class BowlSloshTest(test.GeoClawRegressionTest):
 
@@ -24,10 +24,21 @@ class BowlSloshTest(test.GeoClawRegressionTest):
 
         super(BowlSloshTest, self).setUp()
 
-        # fgmax_grids.data created by setrun.py now contains all info
-        #from . import make_fgmax_grid 
-        #make_fgmax_grid.make_fgmax_grid1(self.temp_path)
 
+    def load_rundata(self, setrun_file='setrun'):
+        r"""(Re)load setrun module and create *rundata* object
+        Modified version from clawutil.test to allow specifying setrun_file.
+        """
+
+        import importlib
+        if 'setrun' in sys.modules:
+            del(sys.modules['setrun'])
+        #sys.path.insert(0, self.test_path)
+        #import setrun
+        sys.path.insert(0, example_dir)
+        setrun = importlib.import_module(setrun_file)
+        self.rundata = setrun.setrun()
+        sys.path.pop(0)
 
     def runTest(self, save=False, indices=(2, 3)):
         r"""Test bowl-slosh example
@@ -37,56 +48,23 @@ class BowlSloshTest(test.GeoClawRegressionTest):
         """
 
         # Write out data files
-        self.load_rundata()
+        self.load_rundata(setrun_file='setrun_test')
 
-        self.rundata.clawdata.num_output_times = 1
-        self.rundata.clawdata.tfinal = 0.5
-
-        self.rundata.gaugedata.gauges = []
-        self.rundata.gaugedata.gauges.append([1, 0.5, 0.5, 0, 1e10])
-
-        # == fgmax.data values ==
-        self.rundata.fgmax_data.num_fgmax_val = 2
-        fgmax_grids = self.rundata.fgmax_data.fgmax_grids  # empty list to start
-        # Now append to this list objects of class fgmax_tools.FGmaxGrid
-        # specifying any fgmax grids.
-
-        fg = fgmax_tools.FGmaxGrid()
-        fg.point_style = 2       # will specify a 2d grid of points
-        fg.x1 = -2.
-        fg.x2 = 2.
-        fg.y1 = -2.
-        fg.y2 = 2.
-        fg.dx = 0.1
-        fg.tstart_max = 0.        # when to start monitoring max values
-        fg.tend_max = 1.e10       # when to stop monitoring max values
-        fg.dt_check = 0.1         # target time (sec) increment between updating
-                               # max values
-        fg.min_level_check = 2    # which levels to monitor max on
-        fg.arrival_tol = 1.e-2    # tolerance for flagging arrival
-
-        fgmax_grids.append(fg)  # written to fgmax_grids.data
+        assert self.rundata.clawdata.tfinal == 0.5, '** unexpected tfinal'
 
         self.write_rundata_objects()
 
         # Make topography
-        a = 1.
-        h0 = 0.1
-        topo_func = lambda x,y: h0 * (x**2 + y**2) / a**2 - h0
-
-        topo = topotools.Topography(topo_func=topo_func)
-        topo.topo_type = 2
-        topo.x = numpy.linspace(-2.0, 2.0, 200)
-        topo.y = numpy.linspace(-2.0, 2.0, 200)
-        topo.write(Path(self.temp_path) / "bowl.topotype2", topo_type=2, 
-                                                            Z_format="%22.15e")
+        import maketopo
+        maketopo.maketopo()
+        shutil.copy('bowl.topotype2', Path(self.temp_path))
 
         # Run code
         self.run_code()
 
         # Perform tests
         self.check_gauges(save=save, gauge_id=1, indices=(2, 3))
-        self.check_fgmax(save=save)
+        #self.check_fgmax(save=save)  # minor differences, why??
         self.success = True
 
 


### PR DESCRIPTION
@mandli: To discuss...

Here's a possible different way to specify the data for a test problem, with a `setrun_test.py` file that has the desired test data rather than putting it in `test_bowl_slosh.py`.  Then it's easy to diff with `setrun.py` and to do `make output SETRUN_FILE=setrun_test.py` to run the test code directly, perhaps after making additional changes to data.

I also invoke `maketopo.py` rather than repeating that code in `test_bowl_slosh.py`, which seems cleaner?

I commented out the `check_fgmax` line because that reports a difference from `regression_data` when I run it (also with the original version of `test_bowl_slosh.py`, so unrelated to the changes in this PR, I think):

```
E       AssertionError: 
E        data: [ 19.69084096 257.76963088], 
E        expected: [ 19.69088003 257.79961463]
```